### PR TITLE
:recycle: Move dependencies to requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/alpha-affinity/snakepacker/buildtime:master as builder
 # install build dependencies
 RUN apt-install curl automake libtool libopenblas-openmp-dev
 
-# build libpostal
+# build libpostal from latest source
 RUN git clone --depth=1 https://github.com/openvenues/libpostal /code/libpostal
 WORKDIR /code/libpostal
 RUN ./bootstrap.sh && \
@@ -17,8 +17,9 @@ RUN ./bootstrap.sh && \
 RUN python3.11 -m venv ${VIRTUAL_ENV} && \
     pip install -U pip setuptools wheel
 
-# install and record server dependencies
-RUN pip install postal fastapi uvicorn[standard] orjson
+# install and record server dependencies (copy runtime source code only in final stage)
+COPY requirements.txt .
+RUN pip install -r requirements.txt
 RUN find-libdeps ${VIRTUAL_ENV} > ${VIRTUAL_ENV}/pkgdeps.txt
 
 # final stage

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ $ curl http://localhost:8001/expandparse?address=30+w+26th+st,+new+york,+ny&coun
 [[["30","house_number"],["w 26th st","road"],["new york","city"],["ny","state"]],...]
 ```
 
-View all possible query parameters at `http://localhost:8001/docs`.
+View all possible query parameters at [`http://localhost:8001/docs`](http://localhost:8001/docs) per the type hints in [`server.py`](server.py).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-postal
-fastapi
-uvicorn[standard]
-orjson
+# compatible release clauses https://www.python.org/dev/peps/pep-0440/#compatible-release
+postal~=1.1
+fastapi~=0.95
+uvicorn[standard]~=0.22
+orjson~=3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+postal
+fastapi
+uvicorn[standard]
+orjson


### PR DESCRIPTION
Advantages:
- per line version control
- standardized filename (recognized by github dependency graph algo)
- explicit layer version caching based on contents of the file