### PR TITLE
:bug: Handle missing language query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ docker run -it --rm -p 8001:8001 ghcr.io/alpha-affinity/libpostal-fastapi:master
 
 Send requests to the server (note that the same label might occur multiple times):
 ```console
-$ curl http://localhost:8001/parse?address=30+w+26th+st,+new+york,+ny&country=us
+$ curl 'http://localhost:8001/parse?address=30+w+26th+st,+new+york,+ny&language=en&country=us'
 [["30","house_number"],["w 26th st","road"],["new york","city"],["ny","state"]]
-$ curl http://localhost:8001/expand?address=30+w+26th+st,+new+york,+ny&languages=en&languages=de
+$ curl 'http://localhost:8001/expand?address=30+w+26th+st,+new+york,+ny&languages=en&languages=de'
 ["30 west 26th saint new york ny","30 west 26th saint new york new york",...]
-$ curl http://localhost:8001/expandparse?address=30+w+26th+st,+new+york,+ny&country=us
-[[["30","house_number"],["w 26th st","road"],["new york","city"],["ny","state"]],...]
+$ curl 'http://localhost:8001/expandparse?address=30+w+26th+st,+new+york,+ny&language=en&country=us'
+[[["30","house_number"],["west 26th saint","road"],["new york","city"],["ny","state"]],...]
 ```
 
 View all possible query parameters at [`http://localhost:8001/docs`](http://localhost:8001/docs) per the type hints in [`server.py`](server.py).

--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import FastAPI, Query
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import ORJSONResponse
 from postal import expand as expand_
 from postal.parser import parse_address
@@ -15,6 +15,9 @@ def parse(
     country: Annotated[str | None, Query(min_length=2, max_length=2)] = None,
 ) -> list[list[str]]:
     """Wrap https://github.com/openvenues/pypostal/blob/1.1/postal/parser.py."""
+    if country is not None and language is None:
+        detail = "Specifying country without specifying language is disallowed"
+        raise HTTPException(status_code=400, detail=detail)
     return parse_address(**locals())
 
 


### PR DESCRIPTION
```py
In [1]: from postal import _parser
In [2]: _parser.parse_address('koningstraat 20, NH', language='nl', country='nl')
Out[2]: [('koningstraat', 'road'), ('20', 'house_number'), ('nh', 'road')]

In [3]: _parser.parse_address('koningstraat 20, NH',  country='nl')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[18], line 1
----> 1 _parser.parse_address('koningstraat 20, NH',  country='nl')

TypeError: Parameter must be bytes or unicode

In [4]: _parser.parse_address('koningstraat 20, NH', language='nl')
Out[4]: [('koningstraat', 'road'), ('20', 'house_number'), ('nh', 'road')]
```